### PR TITLE
Version updates for compiling fix and alire support/instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GSH is an implementation of a [POSIX shell](http://pubs.opengroup.org/onlinepubs
 developed for the Windows platform.
 
 The aim of the project is to provide an efficient UNIX shell
-instantiation for Windows, for non interactive usage.
+instantiation for Windows, for **non interactive** usage.
 
 GSH can be used to compile projects depending on autotools, UNIX make,...
 As it targets specifically Windows platform, GSH differs significantly
@@ -21,6 +21,11 @@ This allows better compiling performance (the build times can be up to 3 or
 ![XKCD on shell escaping](http://imgs.xkcd.com/comics/backslashes.png "Understanding shell escaping!")
 
 Image from [XKCD](http://www.xkcd.com/1638/)
+
+
+Requirements
+--------------------
+GSH is built using Ada and needs an Ada build environment.   Generally this requires the gcc-ada compiler.  If you do not already have a full Ada build environment the easiest way may be to use Alire.  For details on Alire and building using it see the Alire section below.
 
 Build & Installation
 --------------------
@@ -54,6 +59,17 @@ environment:
        $CONFIG_SHELL/configure --prefix=/myinstall_dir
        make)
  
+
+Alire Building
+-------
+Alire is a package manager for Ada but also much more than that.  It can automatically configure entire environments in a sandbox to allow building with whatever versioned dependencies a project may have.  None of the required items will pollute the rest of the computer all installed into alire specific paths under the user.  To install Alire download the latest release from: https://github.com/alire-project/alire/releases  . You do not need to use the installer you can download just the command line tool like: `alr-1.2.2-bin-x86_64-windows.zip`.  This will give you the "alr" binary which is used for managing the environent.
+
+If you run alr not in an msys environment the first time you run the command it will ask to install the tools to a local alr cache folder.  Using powershell go into the gsh folder and run `./bin/alr printenv --powershell | Invoke-Expression`  to setup the build env to include the path items required.  You should likely add alr to your path (at least temporarily) as well.  `$env:PATH="$pwd/bin;" + $env:PATH`.
+
+To build and just accept defaults for dependency packages use:
+`./bin/alr --non-interactive build -- -XBUILD=prod`
+You can then find the final binary in `obj/prod/gsr.exe`
+
 
 License
 -------

--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,9 @@
+name = "GSH"
+description = "GSH is an implementation of a POSIX shell developed for the Windows platform."
+version = "0.2.0-dev"
+
+authors = ["AdaCore"]
+maintainers = ["Nicolas Roche <roche@adacore.com>"]
+maintainers-logins = ["Nikokrock"]
+project-files = ["posix_shell.gpr", "os/os.gpr", "c/c.gpr", "gsh/gsh.gpr" ]
+executables = ["posix_shell"]

--- a/c/c.gpr
+++ b/c/c.gpr
@@ -13,7 +13,7 @@ library project C is
 
    case Build is
       when "dev" =>  Default_Switches := Default_Switches &
-         ("-fpreserve-control-flow", "-fdump-scos");
+         ( "-fdump-scos");
       when "prod" => null;
    end case;
      

--- a/gsh/gsh.gpr
+++ b/gsh/gsh.gpr
@@ -16,7 +16,7 @@ library project GSH is
 
    case Build is
       when "dev" =>  Default_Switches := Default_Switches &
-         ("-fpreserve-control-flow", "-fdump-scos");
+         ( "-fdump-scos");
       when "prod" => null;
    end case;
      

--- a/os/os.gpr
+++ b/os/os.gpr
@@ -15,7 +15,7 @@ library project OS is
 
    case Build is
       when "dev" =>  Default_Switches := Default_Switches &
-         ("-fpreserve-control-flow", "-fdump-scos");
+         ( "-fdump-scos");
       when "prod" => null;
    end case;
      

--- a/posix_shell.gpr
+++ b/posix_shell.gpr
@@ -26,7 +26,7 @@ project Posix_Shell is
 
    case Build is
       when "dev" =>  Default_Switches := Default_Switches &
-         ("-fpreserve-control-flow", "-fdump-scos");
+         ( "-fdump-scos");
       when "prod" => null;
    end case;
 


### PR DESCRIPTION
I think the goal of this project is great (and hopefully not dead).    It pairs incredibly well (at least I hope it will) with a project I am working on with some free time: https://github.com/mitchcapper/WIN64LinuxBuild

A bit of a modern gnuwin32 or what have you.  Infact for use of gsh I don't use any of the gnutools you bundle favoring more updated flavors.

This was built for cygwin use but I hope to get to the point that native windows building with it works.   Not required of course, but, as you are aware, using traditional shells just takes much longer on windows.

I haven't worked with Ada much but these changes allowed me to at least get a production build working.   The additional build notes should make it easy for others (a GH action could so so as well).  

I am sure you will want to make some changes I guessed at the package info file.  

~~I have yet to get the debug build working but am trying to track down that issue.~~
Disabling treating warnings as errors allowed the debug build to build.